### PR TITLE
Remove WindowInsets.navigationBars padding from bottom sheets.

### DIFF
--- a/app/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/HomeComposable.kt
+++ b/app/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/HomeComposable.kt
@@ -162,8 +162,7 @@ fun HomeComposable(navController: NavController, openPreferencesDrawer: () -> Un
             onDismissRequest = {
                 showBottomSheet = false
             },
-            sheetState = sheetState,
-            modifier = Modifier.windowInsetsPadding(WindowInsets.navigationBars)
+            sheetState = sheetState
         ) {
             Box(
                 modifier = Modifier

--- a/app/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/collection/CollectionComposable.kt
+++ b/app/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/collection/CollectionComposable.kt
@@ -200,8 +200,7 @@ fun CollectionComposable(
                 onDismissRequest = {
                     showBottomSheet = false
                 },
-                sheetState = sheetState,
-                modifier = Modifier.windowInsetsPadding(WindowInsets.navigationBars)
+                sheetState = sheetState
             ) {
                 Column(
                     modifier = Modifier.padding(bottom = 32.dp)
@@ -229,8 +228,7 @@ fun CollectionComposable(
                 onDismissRequest = {
                     showAddPostBottomSheet = false
                 },
-                sheetState = showAddPostBottomSheetState,
-                modifier = Modifier.windowInsetsPadding(WindowInsets.navigationBars)
+                sheetState = showAddPostBottomSheetState
             ) {
                 Column(
                     modifier = Modifier.padding(bottom = 32.dp)

--- a/app/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/direct_messages/conversations/ConversationsComposable.kt
+++ b/app/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/direct_messages/conversations/ConversationsComposable.kt
@@ -176,8 +176,7 @@ fun ConversationsComposable(
                 onDismissRequest = {
                     showBottomSheet = false
                 },
-                sheetState = sheetState,
-                modifier = Modifier.windowInsetsPadding(WindowInsets.navigationBars)
+                sheetState = sheetState
             ) {
                 Box(
                     modifier = Modifier

--- a/app/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/TrendingComposable.kt
+++ b/app/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/explore/trending/TrendingComposable.kt
@@ -125,8 +125,7 @@ fun TrendingComposable(navController: NavController, initialPage: Int) {
             onDismissRequest = {
                 showBottomSheet = false
             },
-            sheetState = sheetState,
-            modifier = Modifier.windowInsetsPadding(WindowInsets.navigationBars)
+            sheetState = sheetState
         ) {
             Box(
                 modifier = Modifier

--- a/app/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/post/PostComposable.kt
+++ b/app/src/commonMain/kotlin/com/daniebeler/pfpixelix/ui/composables/post/PostComposable.kt
@@ -605,8 +605,7 @@ fun PostComposable(
             onDismissRequest = {
                 showBottomSheet = 0
             },
-            sheetState = sheetState,
-            modifier = Modifier.windowInsetsPadding(WindowInsets.navigationBars)
+            sheetState = sheetState
         ) {
             if (showBottomSheet == 1) {
                 CommentsBottomSheet(post, navController, viewModel)


### PR DESCRIPTION
ModalBottomSheet already handles insets by default

<img width="812" alt="image" src="https://github.com/user-attachments/assets/75ac7550-a096-440b-8bc9-378d43d4c1a9" />
